### PR TITLE
修改label转换方式

### DIFF
--- a/第二周课后作业/DogCatClassify/DogCat_dataset.py
+++ b/第二周课后作业/DogCatClassify/DogCat_dataset.py
@@ -51,7 +51,9 @@ class DogCatDataset(Dataset):
                 for i in range(len(img_names)):
                     img_name = img_names[i]
                     path_img = os.path.join(root, sub_dir, img_name)
-                    label = DogCat_label[sub_dir]
+                    label_name = img_name.split(".")[0]     # 新增代码
+                    label = DogCat_label[label_name]        # 新增代码
+                    # label = DogCat_label[sub_dir]           # 原代码
                     data_info.append((path_img, int(label)))
 
         return data_info


### PR DESCRIPTION
原代码：                    # label = DogCat_label[sub_dir]           # 原代码
中的sub_dir是文件夹名字，不符合 字典的key（cat 或者dog），导致报错

现改为利用png的名字获取 cat或者dog 

                    label_name = img_name.split(".")[0]     # 新增代码
                    label = DogCat_label[label_name]        # 新增代码